### PR TITLE
Call the touch function from within rotate scripts.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Changelog of raster-feeder
 
 - Make the meta setting template url configurable.
 
+- Call touch_lizard from within rotate scripts.
+
 
 0.5 (2016-12-23)
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,9 @@ incorporated in relevant cronjob lines::
 
     $ bin/touch-lizard <uuid>
 
+Forecast subpackages also offer a TOUCH_LIZARD setting that can be overridden
+in the localconfig to specify uuids to touch right after rotation.
+
 
 TODO
 ----

--- a/raster_feeder/common.py
+++ b/raster_feeder/common.py
@@ -9,7 +9,9 @@ import json
 import logging
 import os
 
+import requests
 import turn
+
 from raster_store import load
 from raster_store import stores
 from . import config
@@ -102,3 +104,27 @@ def rotate(path, region, resource, label='rotate'):
             old.delete(start=start, stop=stop)
 
     logger.info('Rotation of %s completed.' % resource)
+
+
+def touch_lizard(raster_uuid):
+    """Update the raster store metadata using the Lizard API."""
+    url = config.LIZARD_TEMPLATE.format(raster_uuid=raster_uuid)
+    headers = {
+        'username': config.LIZARD_USERNAME,
+        'password': config.LIZARD_PASSWORD,
+    }
+
+    resp = requests.post(url, headers=headers)
+    short_uuid = raster_uuid.split('-')[0]
+    if resp.ok:
+        logger.info(
+            "Metadata update succeeded for %s: %s",
+            short_uuid,
+            resp.json(),
+        )
+    else:
+        logger.error(
+            "Metadata update failed for %s: %s",
+            short_uuid,
+            resp.json(),
+        )

--- a/raster_feeder/harmonie/config.py
+++ b/raster_feeder/harmonie/config.py
@@ -52,7 +52,7 @@ FTP = dict(host='', user='', password='', path='')
 STORE_DIR = join(BUILDOUT_DIR, 'var', 'store')
 
 # Lizard RasterStore UUIDs to touch
-TOUCH_LIZARd = []
+TOUCH_LIZARD = []
 
 # import local settings
 try:

--- a/raster_feeder/harmonie/config.py
+++ b/raster_feeder/harmonie/config.py
@@ -51,6 +51,9 @@ FTP = dict(host='', user='', password='', path='')
 # raster store location
 STORE_DIR = join(BUILDOUT_DIR, 'var', 'store')
 
+# Lizard RasterStore UUIDs to touch
+TOUCH_LIZARd = []
+
 # import local settings
 try:
     from .localconfig import *  # NOQA

--- a/raster_feeder/harmonie/rotate.py
+++ b/raster_feeder/harmonie/rotate.py
@@ -28,6 +28,7 @@ from raster_store import load
 from raster_store import regions
 
 from ..common import rotate
+from ..common import touch_lizard
 from . import config
 
 logger = logging.getLogger(__name__)
@@ -183,6 +184,10 @@ def rotate_harmonie():
     for name, region in regions.items():
         path = join(config.STORE_DIR, name)
         rotate(path=path, region=region, resource=name)
+
+    # touch lizard
+    for raster_uuid in config.TOUCH_LIZARD:
+        touch_lizard(raster_uuid)
 
 
 def get_parser():

--- a/raster_feeder/nowcast/config.py
+++ b/raster_feeder/nowcast/config.py
@@ -37,6 +37,9 @@ STORE_DIR = join(BUILDOUT_DIR, 'var', 'store')
 # FTP connection
 FTP = dict(host='', user='', password='', path='')
 
+# Lizard RasterStore UUIDs to touch
+TOUCH_LIZARD = []
+
 # Import local settings
 try:
     from .localconfig import *  # NOQA

--- a/raster_feeder/nowcast/rotate.py
+++ b/raster_feeder/nowcast/rotate.py
@@ -26,6 +26,7 @@ import numpy as np
 from raster_store import regions
 
 from ..common import rotate
+from ..common import touch_lizard
 from . import config
 
 logger = logging.getLogger(__name__)
@@ -108,6 +109,10 @@ def rotate_nowcast():
     name = config.NAME
     path = join(config.STORE_DIR, name)
     rotate(path=path, region=region, resource=name)
+
+    # touch lizard
+    for raster_uuid in config.TOUCH_LIZARD:
+        touch_lizard(raster_uuid)
 
 
 def get_parser():

--- a/raster_feeder/touch.py
+++ b/raster_feeder/touch.py
@@ -9,8 +9,7 @@ import argparse
 import logging
 import sys
 
-import requests
-
+from . import common
 from . import config
 
 logger = logging.getLogger(__name__)
@@ -32,30 +31,6 @@ def get_parser():
     return parser
 
 
-def touch_lizard(raster_uuid):
-    """Update the raster store metadata using the Lizard API."""
-    url = config.LIZARD_TEMPLATE.format(raster_uuid=raster_uuid)
-    headers = {
-        'username': config.LIZARD_USERNAME,
-        'password': config.LIZARD_PASSWORD,
-    }
-
-    resp = requests.post(url, headers=headers)
-    short_uuid = raster_uuid.split('-')[0]
-    if resp.ok:
-        logger.info(
-            "Metadata update succeeded for %s: %s",
-            short_uuid,
-            resp.json(),
-        )
-    else:
-        logger.error(
-            "Metadata update failed for %s: %s",
-            short_uuid,
-            resp.json(),
-        )
-
-
 def main():
     # logging
     kwargs = vars(get_parser().parse_args())
@@ -72,4 +47,4 @@ def main():
         })
 
     for raster_uuid in kwargs['raster_uuids']:
-        touch_lizard(raster_uuid)
+        common.touch_lizard(raster_uuid)


### PR DESCRIPTION
I had a hard time figuring out where to put all those uuids, while for the current use cases we only need to touch after rotation of forecasts. To prevent adding another layer of complexity (local shell scripts with uuids in them), I propose to put the uuids in the already present localconfig.py files on the server.