### PR TITLE
Verkerk different redis for turn

### DIFF
--- a/raster_feeder/common.py
+++ b/raster_feeder/common.py
@@ -23,11 +23,7 @@ from raster_store.blocks import RasterStoreSource
 from . import config
 
 logger = logging.getLogger(__name__)
-locker = turn.Locker(
-    host=config.REDIS_HOST,
-    db=config.REDIS_DB,
-    password=config.REDIS_PASSWORD
-)
+locker = turn.Locker(host=config.REDIS_HOST_TURN)
 
 
 def create_tumbler(path, depth, average=False, **kwargs):

--- a/raster_feeder/config.py
+++ b/raster_feeder/config.py
@@ -16,10 +16,13 @@ LOG_DIR = PACKAGE_DIR / "var" / "log"
 STORE_DIR.mkdir(parents=True, exist_ok=True)
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 
-# redis host for mtime cache and turn locking system
+# redis host for mtime cache
 REDIS_HOST = 'redis'
 REDIS_DB = 0
 REDIS_PASSWORD = None
+
+# redis host for turn locking system
+REDIS_HOST_TURN = 'redis'
 
 # Lizard API credentials
 LIZARD_USERNAME = 'override'

--- a/raster_feeder/nrr/config.py
+++ b/raster_feeder/nrr/config.py
@@ -12,10 +12,13 @@ from ..config import PACKAGE_DIR  # NOQA
 from ..config import STORE_DIR  # NOQA
 from ..config import LOG_DIR  # NOQA
 
-# Redis
+# Redis for mtime cache
 from ..config import REDIS_PASSWORD  # NOQA
 from ..config import REDIS_HOST  # NOQA
 from ..config import REDIS_DB  # NOQA
+
+# Redis for turn
+from ..config import REDIS_HOST_TURN  # NOQA
 
 # data is read from here
 CALIBRATE_DIR = PACKAGE_DIR / "var" / "calibrate"

--- a/raster_feeder/nrr/move.py
+++ b/raster_feeder/nrr/move.py
@@ -58,11 +58,7 @@ def move(time_name, source_name, target_name):
     target = get_store(time_name=time_name, store_name=target_name)
 
     # promote
-    locker = turn.Locker(
-        host=config.REDIS_HOST,
-        db=config.REDIS_DB,
-        password=config.REDIS_PASSWORD
-    )
+    locker = turn.Locker(host=config.REDIS_HOST_TURN)
     label = 'move: {} => {}'.format(source_name, target_name)
     template = "Move from '{}/{}' into '{}/{}'."
     message = template.format(time_name, source_name, time_name, target_name)

--- a/raster_feeder/nrr/store.py
+++ b/raster_feeder/nrr/store.py
@@ -270,11 +270,7 @@ def command(text, delivery, timeframes, prodcodes):
     )
     logger.info(message)
 
-    locker = turn.Locker(
-        host=config.REDIS_HOST,
-        db=config.REDIS_DB,
-        password=config.REDIS_PASSWORD
-    )
+    locker = turn.Locker(host=config.REDIS_HOST_TURN)
     for timeframe in timeframes:
         for prodcode in prodcodes:  # use reversed order
 

--- a/raster_feeder/tests/test_steps.py
+++ b/raster_feeder/tests/test_steps.py
@@ -44,8 +44,8 @@ class TestRotateSteps(unittest.TestCase):
         rotate_steps()
 
         extract_region_patch = patches['extract_region']
-        self.assertEqual(extract_region_patch.call_count, 1)
-        self.assertIn(correct, extract_region_patch.call_args[0][0])
+        assert extract_region_patch.call_count == 1
+        assert extract_region_patch.call_args[1]["path"].endswith(correct)
 
     def test_pick_newest(self, **patches):
         patches['FTPServer'].return_value = self.mock_ftp
@@ -58,8 +58,8 @@ class TestRotateSteps(unittest.TestCase):
         rotate_steps()
 
         extract_region_patch = patches['extract_region']
-        self.assertEqual(extract_region_patch.call_count, 1)
-        self.assertIn(correct, extract_region_patch.call_args[0][0])
+        assert extract_region_patch.call_count == 1
+        assert extract_region_patch.call_args[1]["path"].endswith(correct)
 
     def test_no_files(self, **patches):
         patches['FTPServer'].return_value = self.mock_ftp
@@ -70,7 +70,7 @@ class TestRotateSteps(unittest.TestCase):
         rotate_steps()
 
         extract_region_patch = patches['extract_region']
-        self.assertEqual(extract_region_patch.call_count, 0)
+        assert extract_region_patch.call_count == 0
 
     def test_file_already_done(self, **patches):
         patches['FTPServer'].return_value = self.mock_ftp
@@ -83,7 +83,7 @@ class TestRotateSteps(unittest.TestCase):
         rotate_steps()
 
         extract_region_patch = patches['extract_region']
-        self.assertEqual(extract_region_patch.call_count, 0)
+        assert extract_region_patch.call_count == 0
 
     def test_file_is_newer(self, **patches):
         patches['FTPServer'].return_value = self.mock_ftp
@@ -96,8 +96,8 @@ class TestRotateSteps(unittest.TestCase):
         rotate_steps()
 
         extract_region_patch = patches['extract_region']
-        self.assertEqual(extract_region_patch.call_count, 1)
-        self.assertIn(correct, extract_region_patch.call_args[0][0])
+        assert extract_region_patch.call_count == 1
+        assert extract_region_patch.call_args[1]["path"].endswith(correct)
 
     def test_file_is_older(self, **patches):
         patches['FTPServer'].return_value = self.mock_ftp
@@ -110,13 +110,13 @@ class TestRotateSteps(unittest.TestCase):
         rotate_steps()
 
         extract_region_patch = patches['extract_region']
-        self.assertEqual(extract_region_patch.call_count, 0)
+        assert extract_region_patch.call_count == 0
 
 
 @mark.skipif(not TESTDATA_PATH.exists(), reason='No testdata available.')
 class TestExtract(unittest.TestCase):
     def test_bands(self):
-        region = extract_region(str(TESTDATA_PATH))
+        region = extract_region(path=TESTDATA_PATH, percentile=75)
         self.assertEqual(region.box.data.shape[0], config.DEPTH)
 
 


### PR DESCRIPTION
I have a different redis config used for turn, because the lizard volatile redis is dropping keys all day, braking `turn`. I also fixed the tests for the steps, since I totally bypassed the review system when implementing the "steps-single" script, leaving it in a broken state. My apologies, that was not nice.

In another private repo (rr-data) all the localconfigs are kept. There REDIS_HOST_TURN configs are set to 'localhost'. That is ok for the (staging & production) rr task servers, because they already have redis for celery and the only function of turn is now to prevent overlapping cronjobs on the same resource.